### PR TITLE
頂点情報をUnityに送るサンプル

### DIFF
--- a/OSCclient.ipynb
+++ b/OSCclient.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Skinning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tf_pose.common import read_imgfile\n",
+    "from lib.common import draw_circle\n",
+    "from lib.contour import find_human_contour\n",
+    "from lib.skeleton import SkeletonImplement\n",
+    "from lib.skinning import Skinning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2018-10-26 22:37:00,512] [TfPoseEstimator] [INFO] loading graph from C:\\Users\\kukikeita\\Desktop\\Python\\ShadowSkinning\\tf_pose_data\\graph/mobilenet_thin/graph_opt.pb(default size=368x368)\n"
+     ]
+    }
+   ],
+   "source": [
+    "src = read_imgfile(\"./images/shadow.jpg\", None, None)\n",
+    "dst = src.copy()\n",
+    "human_contour = find_human_contour(src)\n",
+    "\n",
+    "skeletonImplement = SkeletonImplement()\n",
+    "humans = skeletonImplement.infer_skeletons(src)\n",
+    "\n",
+    "skinning = Skinning(src, humans[0], human_contour, algorithm=\"nearest_neighbour_within_contour\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "611"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1395"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "611"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "611"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "18"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "vertices = skinning.contour_vertex_positions\n",
+    "vertices = [[int(x[0]), int(x[1])] for x in vertices]\n",
+    "triangles = skinning.triangle_vertex_indices\n",
+    "nearest_joints = skinning.nearest_body_part_indices\n",
+    "influence = skinning.influence\n",
+    "joints = skinning.body_part_positions\n",
+    "joints = [[x[0], x[1]] for x in joints]\n",
+    "\n",
+    "display(len(vertices))\n",
+    "display(len(triangles)*3)\n",
+    "display(len(nearest_joints))\n",
+    "display(len(influence))\n",
+    "display(len(joints))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OSC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pythonosc import udp_client\n",
+    "from time import sleep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ip = \"127.0.0.1\"\n",
+    "port = 5005"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = udp_client.SimpleUDPClient(ip, port)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# address\n",
+    "vertices_address = \"/vertices\"\n",
+    "triangles_address = \"/triangles\"\n",
+    "nearest_joints_address = \"/nearest_joints\"\n",
+    "influence_address = \"/influence\"\n",
+    "joints_address = \"/joints\"\n",
+    "end_address = \"/end\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 軽い順で送らないと後半が欠落する可能性あり\n",
+    "# 安全のためsleepいれとく（要修正）\n",
+    "client.send_message(joints_address, joints)\n",
+    "sleep(0.1)\n",
+    "client.send_message(influence_address, influence)\n",
+    "sleep(0.1)\n",
+    "client.send_message(nearest_joints_address, nearest_joints)\n",
+    "sleep(0.1)\n",
+    "client.send_message(triangles_address, triangles)\n",
+    "sleep(0.1)\n",
+    "client.send_message(vertices_address, vertices)\n",
+    "sleep(0.1)\n",
+    "client.send_message(end_address, \"end\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lib/algorithm.py
+++ b/lib/algorithm.py
@@ -42,7 +42,10 @@ def calculate_nearest_neighbour_within_contour(img, contour_vertex_positions, bo
 
     for i, body_part_position in enumerate(body_part_positions):
         black_pixels_body_part_dict[body_part_position] = i
-        del remaining_pixels_body_part_dict[body_part_position]
+        try:
+            del remaining_pixels_body_part_dict[body_part_position]
+        except KeyError:
+            pass
 
     while len(remaining_pixels_body_part_dict) > 0:
         for pixel_position in list(remaining_pixels_body_part_dict):
@@ -79,7 +82,10 @@ def calculate_k_nearest_neighbour_within_contour(img, contour_vertex_positions, 
                       for black_pixel_position in black_pixel_positions}
 
     for index, body_part_position in enumerate(body_part_positions):
-        influence_dict[body_part_position][index] = 1
+        try:
+            influence_dict[body_part_position][index] = 1
+        except KeyError:
+            pass
 
     count = 0
     for _ in range(iteration):  # 輪郭点それぞれに一個以上集まったら？

--- a/lib/skinning.py
+++ b/lib/skinning.py
@@ -21,6 +21,7 @@ class Skinning:
         # body_part_positions
         for i in range(CocoPart.Background.value):
             if i not in human.body_parts.keys():
+                self.body_part_positions.append((0,0))
                 continue
 
             body_part = human.body_parts[i]
@@ -61,7 +62,7 @@ class Skinning:
                                                                                         self.contour_vertex_positions,
                                                                                         self.body_part_positions)
         elif algorithm == "k_nearest_neighbour_within_contour":
-            calculate_k_nearest_neighbour_within_contour(src, self.contour_vertex_positions, self.body_part_positions)
+            self.nearest_body_part_indices = calculate_k_nearest_neighbour_within_contour(src, self.contour_vertex_positions, self.body_part_positions)
         else:
             print("The algorithm name is not found.")
             sys.exit(1)


### PR DESCRIPTION
とりあえずjupyterから送る
`nearest_neighbour_within_contour`対応
# 変更内容
* 関節の配列を18に固定
  * 取得できてない場合は座標を(0,0)とした
 * 上記変更によるdictionalyのkeyErrorハンドリング

影響関節インデックス配列とその影響度配列は要素の長さが同じだとunity側では嬉しい
Unity側は
https://github.com/Keita-Kuki/AutonomicShadow
