### PR TITLE
keep inference model deploy

### DIFF
--- a/draw_skeleton.py
+++ b/draw_skeleton.py
@@ -11,7 +11,6 @@ if __name__ == '__main__':
 
     skeletonImplement = SkeletonImplement()
     human = skeletonImplement.infer_skeleton(src)
-    human = skeletonImplement.remove_unused_joints(human)
     dst = skeletonImplement.draw_skeleton(dst, human)
 
     plt.imshow(cv2.cvtColor(dst, cv2.COLOR_BGR2RGB))

--- a/lib/skeleton.py
+++ b/lib/skeleton.py
@@ -30,14 +30,12 @@ SkeletonColors = [
 
 
 class SkeletonImplement:
-    def __init__(self, tf_config=None):
-        self.estimator = TfPoseEstimator(get_graph_path("mobilenet_thin"), target_size=(368, 368), tf_config=tf_config)
+    def __init__(self, tf_config=None, target_size=(368, 368)):
+        self.estimator = TfPoseEstimator(get_graph_path("mobilenet_thin"), target_size=target_size, tf_config=tf_config)
 
     def infer_skeleton(self, src):
         humans = self.estimator.inference(src, upsample_size=4.0)
-        return humans[0]
-
-    def remove_unused_joints(self, human):
+        human = humans[0]
         for unused_index in [14, 15, 16, 17, 18]:
             if unused_index in human.body_parts.keys():
                 del human.body_parts[unused_index]

--- a/nearest_neighbour_skinning.py
+++ b/nearest_neighbour_skinning.py
@@ -17,15 +17,13 @@ if __name__ == '__main__':
 
     skeletonImplement = SkeletonImplement()
     human = skeletonImplement.infer_skeleton(src)
-    human = skeletonImplement.remove_unused_joints(human)
 
     skeletonTest = SkeletonTest(human, human_contour, src.shape)
-    skeletonTest.report()
     if not skeletonTest.is_reliable():
+        skeletonTest.report()
         print("This skeleton model is not reliable.")
         sys.exit(0)
 
-    # skinning = Skinning(src, humans, human_contour)
     skinning = Skinning(src, human, human_contour, algorithm="nearest_neighbour_within_contour")
 
     # visualization
@@ -33,6 +31,5 @@ if __name__ == '__main__':
         draw_circle(dst, skinning.contour_vertex_positions[i], (255, 0, 0))
         draw_circle(dst, skinning.body_part_positions[skinning.nearest_body_part_indices[i]])
 
-    # cv2.imwrite("./images/nearest.png", dst)
     plt.imshow(cv2.cvtColor(dst, cv2.COLOR_BGR2RGB))
     plt.show()

--- a/watch_image_generation_then_get_shadow_info.py
+++ b/watch_image_generation_then_get_shadow_info.py
@@ -1,42 +1,25 @@
-import sys
+import time
 
-from tf_pose.common import read_imgfile
+from watchdog.observers import Observer
 
-from lib.contour import find_human_contour
-from lib.skeleton import SkeletonImplement, SkeletonTest
-from lib.shadow import Shadow
-from lib.watch import watch_image_generation
+from lib.skeleton import SkeletonImplement
+from lib.watch import ImageGenerationEventHandler
 
 TARGET_DIRECTORY_PATH = "./images"
 
-
-def get_shadow_info(image_path, frame_index):
-    src = read_imgfile(image_path, None, None)
-
-    if src is None:
-        print(image_path + " is not found.")
-        return
-
-    print("Frame Index:", frame_index)
-
-    human_contour = find_human_contour(src)
-
-    skeleton_implement = SkeletonImplement()
-    human = skeleton_implement.infer_skeleton(src)
-    human = skeleton_implement.remove_unused_joints(human)
-
-    skeleton_test = SkeletonTest(human, human_contour, src.shape)
-    skeleton_test.report()
-    if not skeleton_test.is_reliable():
-        print("This skeleton model is not reliable.")
-        sys.exit(0)
-
-    shadow = Shadow(src.shape, human, human_contour)
-
-    print("The number of body parts:", len(shadow.body_part_positions))
-    print("The number of contour vertices:", len(shadow.contour_vertex_positions))
-    print("The number of triangle vertices:", len(shadow.triangle_vertex_indices))
-
-
 if __name__ == '__main__':
-    watch_image_generation(get_shadow_info, TARGET_DIRECTORY_PATH)
+    skeleton_implement = SkeletonImplement(target_size=(368, 368))
+
+    event_handler = ImageGenerationEventHandler(["*.jpg"], skeleton_implement)
+    observer = Observer()
+    observer.schedule(event_handler, TARGET_DIRECTORY_PATH)
+    observer.start()
+    print("watching image generation...")
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+
+    observer.join()


### PR DESCRIPTION
- `watch_image_generation_then_get_shadow_info.py`にて、openposeの推測モデルを展開したままディレクトリ監視のwhileループを回すサンプルに変更

- `SkeletonImplement` クラスの`remove_unused_joints`関数を他関数に吸収させた(必ず使うため)